### PR TITLE
Fix: fix tailwind error on non-tailwind stack selection

### DIFF
--- a/.changeset/loud-flies-play.md
+++ b/.changeset/loud-flies-play.md
@@ -1,0 +1,5 @@
+---
+"@thanka-digital/beej-react": patch
+---
+
+Fix: fix tailwind error on non-tailwind stack selection

--- a/packages/beej-react/cli/utils/contentRemoveByLines.ts
+++ b/packages/beej-react/cli/utils/contentRemoveByLines.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+
+export const contentRemoveByLines = (contentPath: string, linesToRemove: number[]) => {
+  const content = readFileSync(contentPath, "utf-8");
+  let contentAfterRemoval = "";
+  const contentByLines = content.split(/\r\n|\r|\n/);
+
+  for (let index = 0; index < contentByLines.length; index++) {
+    if (!linesToRemove.includes(index)) {
+      contentAfterRemoval += contentByLines[index] + "\n";
+    }
+  }
+
+  return contentAfterRemoval;
+}

--- a/packages/beej-react/main/src/index.css
+++ b/packages/beej-react/main/src/index.css
@@ -1,16 +1,3 @@
-@import "tailwindcss";
-
-@theme {
-  --color-primary: #3490dc;
-  --color-secondary: #ffed4a;
-  --color-accent: #ff3860;
-  --color-danger: #e3342f;
-  --color-success: #38c172;
-  --color-warning: #f6993f;
-  --color-info: #6cb2eb;
-  --color-neutral: #3d4451;
-}
-
 :root {
   font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;

--- a/packages/beej-react/main/src/main.tsx
+++ b/packages/beej-react/main/src/main.tsx
@@ -1,10 +1,12 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
+import "./styles/tailwind.css";
+
 import App from "./App.tsx";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
     <App />
-  </StrictMode>,
+  </StrictMode>
 );

--- a/packages/beej-react/main/src/styles/tailwind.css
+++ b/packages/beej-react/main/src/styles/tailwind.css
@@ -1,0 +1,25 @@
+@import "tailwindcss";
+
+@theme {
+  --color-primary: #475199;
+  --color-primary-dark: #333D79;
+  --color-primary-subtle: #F1F2F9;
+  --color-primary-light: #DFE1EC;
+  --color-primary-fg: #FFFFFF;
+
+  --color-secondary: #E7202C;
+  --color-secondary-dark: #CD1220;
+  --color-secondary-subtle: #FFE9EB;
+  --color-secondary-light: #FFD2D5;
+  --color-secondary-fg: #FFFFFF;
+
+  --color-gray-lighter: #DADADA;
+  --color-gray-darker: #9C9B9B;
+
+  --color-accent: #ff3860;
+  --color-danger: #e3342f;
+  --color-success: #38c172;
+  --color-warning: #f6993f;
+  --color-info: #6cb2eb;
+  --color-neutral: #3d4451;
+}

--- a/packages/beej-react/main/vite.config.ts
+++ b/packages/beej-react/main/vite.config.ts
@@ -5,5 +5,9 @@ import tailwindcss from "@tailwindcss/vite";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), tsconfigPaths(), tailwindcss()],
+  plugins: [
+    react(),
+    tsconfigPaths(),
+    tailwindcss(),
+  ],
 });

--- a/packages/beej-react/package.json
+++ b/packages/beej-react/package.json
@@ -77,6 +77,8 @@
     "typescript": "^5.7.3",
     "typescript-eslint": "^8.24.0",
     "unbuild": "^2.0.0",
+    "vite": "^6.3.5",
+    "vite-tsconfig-paths": "^5.1.4",
     "zustand": "^5.0.4"
   },
   "publishConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,6 +235,12 @@ importers:
       unbuild:
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.7.3)
+      vite:
+        specifier: ^6.3.5
+        version: 6.3.5(@types/node@22.13.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.7.3)(vite@6.3.5(@types/node@22.13.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0))
       zustand:
         specifier: ^5.0.4
         version: 5.0.4(@types/react@19.0.8)(immer@10.1.1)(react@19.0.0)(use-sync-external-store@1.5.0(react@19.0.0))
@@ -4856,6 +4862,9 @@ packages:
     resolution: {integrity: sha512-Y1zNGV+pzQdh7H39l9zgB4PJqjRNqydvdYCDG4HFXM4XuvSaQQlEc91IU1yALL8gUTDomgBAfz3XJdmUS+oo0w==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
+  globrex@0.1.2:
+    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -8063,6 +8072,16 @@ packages:
       '@swc/wasm':
         optional: true
 
+  tsconfck@3.1.5:
+    resolution: {integrity: sha512-CLDfGgUp7XPswWnezWwsCRxNmgQjhYq3VXHM0/XIRxhVrKw0M1if9agzryh1QS3nxjCROvV+xWxoJO1YctzzWg==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+    peerDependencies:
+      typescript: ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
@@ -8394,6 +8413,14 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
+
+  vite-tsconfig-paths@5.1.4:
+    resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
 
   vite@6.3.5:
     resolution: {integrity: sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==}
@@ -11887,7 +11914,7 @@ snapshots:
 
   '@types/acorn@4.0.6':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
 
   '@types/body-parser@1.19.5':
     dependencies:
@@ -11918,7 +11945,7 @@ snapshots:
 
   '@types/eslint@9.6.1':
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       '@types/json-schema': 7.0.15
 
   '@types/estree-jsx@1.0.5':
@@ -14240,7 +14267,7 @@ snapshots:
 
   estree-util-attach-comments@3.0.0:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
 
   estree-util-build-jsx@3.0.1:
     dependencies:
@@ -14696,6 +14723,8 @@ snapshots:
       merge2: 1.4.1
       slash: 4.0.0
 
+  globrex@0.1.2: {}
+
   gopd@1.2.0: {}
 
   got@12.6.1:
@@ -14804,7 +14833,7 @@ snapshots:
 
   hast-util-to-estree@3.1.2:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       comma-separated-tokens: 2.0.3
@@ -15938,7 +15967,7 @@ snapshots:
 
   micromark-extension-mdx-expression@3.0.0:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       devlop: 1.1.0
       micromark-factory-mdx-expression: 2.0.2
       micromark-factory-space: 2.0.1
@@ -15950,7 +15979,7 @@ snapshots:
   micromark-extension-mdx-jsx@3.0.1:
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       micromark-factory-mdx-expression: 2.0.2
@@ -15967,7 +15996,7 @@ snapshots:
 
   micromark-extension-mdxjs-esm@3.0.0:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.2
       micromark-util-character: 2.1.1
@@ -16003,7 +16032,7 @@ snapshots:
 
   micromark-factory-mdx-expression@2.0.2:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       devlop: 1.1.0
       micromark-factory-space: 2.0.1
       micromark-util-character: 2.1.1
@@ -16078,7 +16107,7 @@ snapshots:
   micromark-util-events-to-acorn@2.0.2:
     dependencies:
       '@types/acorn': 4.0.6
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       '@types/unist': 3.0.3
       devlop: 1.1.0
       estree-util-visit: 2.0.0
@@ -17525,7 +17554,7 @@ snapshots:
 
   recma-parse@1.0.0:
     dependencies:
-      '@types/estree': 1.0.6
+      '@types/estree': 1.0.7
       esast-util-from-js: 2.0.1
       unified: 11.0.5
       vfile: 6.0.3
@@ -18452,6 +18481,10 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.11.24
 
+  tsconfck@3.1.5(typescript@5.7.3):
+    optionalDependencies:
+      typescript: 5.7.3
+
   tslib@1.14.1: {}
 
   tslib@2.8.1: {}
@@ -18818,6 +18851,17 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
+
+  vite-tsconfig-paths@5.1.4(typescript@5.7.3)(vite@6.3.5(@types/node@22.13.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)):
+    dependencies:
+      debug: 4.4.0
+      globrex: 0.1.2
+      tsconfck: 3.1.5(typescript@5.7.3)
+    optionalDependencies:
+      vite: 6.3.5(@types/node@22.13.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   vite@6.3.5(@types/node@22.13.0)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0):
     dependencies:


### PR DESCRIPTION
This PR closes #26 removing the error of tailwind codes when non-tailwind stack is selected.

It is done by removing the `tailwindcss` related codes from `main.tsx` and `vite.config.ts` file when non-tailwind component library is selected.